### PR TITLE
Undefined property: DOMComment::$wholeText

### DIFF
--- a/src/voku/helper/HtmlMin.php
+++ b/src/voku/helper/HtmlMin.php
@@ -835,7 +835,7 @@ class HtmlMin
 
       } elseif ($child instanceof \DOMComment) {
 
-        $html .= $child->wholeText;
+        $html .= '<!--' . $child->textContent . '-->';
 
       }
     }

--- a/tests/HtmlMinTest.php
+++ b/tests/HtmlMinTest.php
@@ -775,4 +775,36 @@ class HtmlMinTest extends \PHPUnit\Framework\TestCase
     $actual = $this->compressor->minify($input);
     self::assertSame($expected, $actual);
   }
+
+  public function testDoRemoveCommentsWithFalse()
+  {
+    $this->compressor->doRemoveComments(false);
+
+    $html = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test</title>
+</head>
+<body>
+<!-- do not remove comment -->
+<hr />
+<!--
+do not remove comment
+-->
+</body>
+</html>
+
+HTML;
+
+    $actual = $this->compressor->minify($html);
+
+    $expectedHtml = <<<'HTML'
+<!DOCTYPE html><html><head><title>Test</title> <body><!-- do not remove comment --> <hr><!--
+do not remove comment
+-->
+HTML;
+
+    self::assertSame($expectedHtml, $actual);
+  }
 }


### PR DESCRIPTION
Hello, the DOMComment object has no wholeText property.

https://github.com/voku/HtmlMin/blob/0da9ff11be965bac32ffb867d5f2092a8e321f8a/src/voku/helper/HtmlMin.php#L836-L838

I added a test and applied a possible fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/htmlmin/23)
<!-- Reviewable:end -->
