### PR TITLE
keep prefix on non-resources + make domain local

### DIFF
--- a/src/voku/helper/HtmlMin.php
+++ b/src/voku/helper/HtmlMin.php
@@ -188,6 +188,21 @@ class HtmlMin implements HtmlMinInterface
     private $doRemoveHttpsPrefixFromAttributes = false;
 
     /**
+     * @var bool
+     */
+    private $keepPrefixOnExternalAttributes = false;
+
+    /**
+     * @var bool
+     */
+    private $doMakeSameDomainLinksRelative = false;
+
+    /**
+     * @var string
+     */
+    private $localDomain = '';
+
+    /**
      * @var array
      */
     private $domainsToRemoveHttpPrefixFromAttributes = [
@@ -420,7 +435,57 @@ class HtmlMin implements HtmlMinInterface
         $this->doRemoveHttpsPrefixFromAttributes = $doRemoveHttpsPrefixFromAttributes;
 
         return $this;
+	}
+	
+    /**
+     * @param bool $keepPrefixOnExternalAttributes
+     *
+     * @return $this
+     */
+    public function keepPrefixOnExternalAttributes(bool $keepPrefixOnExternalAttributes = true): self
+    {
+        $this->keepPrefixOnExternalAttributes = $keepPrefixOnExternalAttributes;
+
+        return $this;
     }
+	
+    /**
+     * @param bool $doMakeSameDomainLinksRelative
+     *
+     * @return $this
+     */
+    public function doMakeSameDomainLinksRelative(bool $doMakeSameDomainLinksRelative = true): self
+    {
+        $this->doMakeSameDomainLinksRelative = $doMakeSameDomainLinksRelative;
+
+        return $this;
+    }
+	
+    /**
+     * @param bool $setLocalDomain
+     *
+     * @return $this
+     */
+    public function setLocalDomain(string $localDomain = ''): self
+    {
+		if ($localDomain === ''){
+			$this->localDomain = $_SERVER['SERVER_NAME'];
+		}else{
+			$this->localDomain = $localDomain;
+			preg_replace('/(https?:)?\/\//', '', $this->localDomain);
+		}
+
+        return $this;
+	}
+	
+	/**
+     * @param void
+     *
+     * @return $this->localDomain
+     */
+	public function getLocalDomain(): string{
+		return $this->localDomain;
+	}
 
     /**
      * @param bool $doRemoveOmittedHtmlTags
@@ -1048,6 +1113,30 @@ class HtmlMin implements HtmlMinInterface
     public function isDoRemoveHttpsPrefixFromAttributes(): bool
     {
         return $this->doRemoveHttpsPrefixFromAttributes;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isKeepPrefixOnExternalAttributes(): bool
+    {
+        return $this->keepPrefixOnExternalAttributes;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDoMakeSameDomainLinksRelative(): bool
+    {
+        return $this->doMakeSameDomainLinksRelative;
+	}
+	
+    /**
+     * @param bool
+     */
+    public function isLocalDomainSet(): bool
+    {
+		return (!empty($this->localDomain));
     }
 
     /**

--- a/src/voku/helper/HtmlMin.php
+++ b/src/voku/helper/HtmlMin.php
@@ -471,8 +471,7 @@ class HtmlMin implements HtmlMinInterface
 		if ($localDomain === ''){
 			$this->localDomain = $_SERVER['SERVER_NAME'];
 		}else{
-			$this->localDomain = $localDomain;
-			preg_replace('/(https?:)?\/\//', '', $this->localDomain);
+			$this->localDomain = rtrim(preg_replace('/(https?:)?\/\//', '', $localDomain), '/');
 		}
 
         return $this;
@@ -483,7 +482,8 @@ class HtmlMin implements HtmlMinInterface
      *
      * @return $this->localDomain
      */
-	public function getLocalDomain(): string{
+	public function getLocalDomain(): string
+	{
 		return $this->localDomain;
 	}
 

--- a/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
+++ b/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
@@ -67,7 +67,8 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
                     $attrValue,
                     $attrName,
                     'http',
-                    $attributes
+					$attributes,
+					$htmlMin
                 );
             }
 
@@ -76,8 +77,25 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
                     $attrValue,
                     $attrName,
                     'https',
-                    $attributes
+                    $attributes,
+					$htmlMin
                 );
+            }
+
+            if ($htmlMin->isDoMakeSameDomainLinksRelative()) {
+				if (!$htmlMin->isLocalDomainSet()){
+					$htmlMin->setLocalDomain();
+				}
+				$localDomain = $htmlMin->getLocalDomain();
+				if (
+					(($attrName === 'href') || $attrName === 'src' || $attrName === 'srcset' || $attrName === 'action')
+					&&
+					!(isset($attributes['rel']) && $attributes['rel'] === 'external')
+					&&
+					!(isset($attributes['target']) && $attributes['target'] === '_blank')
+				) {
+					$attrValue = \preg_replace("/^((https?:)?\/\/)?{$localDomain}(?!\w)(\/?)/", '/', $attrValue);
+				}
             }
 
             if ($this->removeAttributeHelper($element->tag, $attrName, $attrValue, $attributes, $htmlMin)) {
@@ -208,11 +226,12 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
         string $attrValue,
         string $attrName,
         string $scheme,
-        array $attributes
+		array $attributes,
+		HtmlMinInterface $htmlMin
     ): string {
         /** @noinspection InArrayCanBeUsedInspection */
         if (
-            ($attrName === 'href' || $attrName === 'src' || $attrName === 'srcset' || $attrName === 'action')
+            (($attrName === 'href' && !$htmlMin->isKeepPrefixOnExternalAttributes()) || $attrName === 'src' || $attrName === 'srcset' || $attrName === 'action')
             &&
             !(isset($attributes['rel']) && $attributes['rel'] === 'external')
             &&

--- a/src/voku/helper/HtmlMinInterface.php
+++ b/src/voku/helper/HtmlMinInterface.php
@@ -108,6 +108,26 @@ interface HtmlMinInterface
     public function isDoRemoveHttpsPrefixFromAttributes(): bool;
 
     /**
+     * @return bool
+     */
+    public function isKeepPrefixOnExternalAttributes(): bool;
+
+    /**
+     * @return bool
+     */
+	public function isDoMakeSameDomainLinksRelative(): bool;
+
+	/**
+     * @param bool
+     */
+    public function isLocalDomainSet(): bool;
+	
+	/**
+     * @return string
+     */
+	public function getLocalDomain(): string;
+
+    /**
      * @return array
      */
     public function getDomainsToRemoveHttpPrefixFromAttributes(): array;

--- a/tests/HtmlMinTest.php
+++ b/tests/HtmlMinTest.php
@@ -1240,5 +1240,39 @@ HTML;
 
         $htmlMin = new HtmlMin();
         static::assertSame($expected, $htmlMin->minify($html));
-    }
+	}
+	
+	public function testRelativeLinks()
+	{
+		$html='<a href="https://www.example.com">Just an example</a>';
+		$expected='<a href=/>Just an example</a>';
+
+		$htmlMin = new HtmlMin();
+		$htmlMin->doMakeSameDomainLinksRelative();
+		$htmlMin->setLocalDomain('www.example.com');
+		static::assertSame($expected, $htmlMin->minify($html));
+	}
+
+	public function testSetLocalDomain()
+	{
+		$html='<a href="www.example.com">Just an example</a>';
+		$expected='<a href=/>Just an example</a>';
+
+		$htmlMin = new HtmlMin();
+		$htmlMin->doMakeSameDomainLinksRelative();
+		$htmlMin->setLocalDomain('https://www.example.com/');
+		static::assertSame($expected, $htmlMin->minify($html));
+	}
+
+	public function testKeepPrefixOnExternalAttributes(){
+		$html='<a href="http://www.example.com/">No remove</a><img src="http://www.example.com/" />';
+		$expected = '<a href=http://www.example.com/>No remove</a><img src=//www.example.com/>';
+
+		$htmlMin = new HtmlMin();
+		$htmlMin->doRemoveHttpPrefixFromAttributes();
+		$htmlMin->keepPrefixOnExternalAttributes();
+		static::assertSame($expected, $htmlMin->minify($html));
+
+
+	}
 }


### PR DESCRIPTION
**Followup to discussion on** #43

#### Proposed Changes
* Allow keeping of `http`/`https` prefix on `href`/non-rescource links.
* Add option to make all same-domain links relative.
* Add option to set domain manually

#### Notes
- `makeSameDomainLinksRelative()` disregards `isKeepPrefixOnExternalAttributes()`. This can be easily changed. The logic being that a library user choosing `LinksRelative` expects it to apply to both resources and links. Which is not the same expectation of choosing `KeepPrefixOnExternal` - which is to keep outgoing information intact.
- Setting domain manually allows running `HtmlMin` without strong coupling of `HtmlMin` and `$_SERVER`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/htmlmin/44)
<!-- Reviewable:end -->
