### PR TITLE
`KeepPrefixOnExternal` fix and `sameDomainLinksRelative` API clean-up

### DIFF
--- a/src/voku/helper/HtmlMin.php
+++ b/src/voku/helper/HtmlMin.php
@@ -454,21 +454,11 @@ class HtmlMin implements HtmlMinInterface
      *
      * @return $this
      */
-    public function doMakeSameDomainLinksRelative(bool $doMakeSameDomainLinksRelative = true): self
+    public function doMakeSameDomainLinksRelative(string $localDomain = ''): self
     {
-        $this->doMakeSameDomainLinksRelative = $doMakeSameDomainLinksRelative;
+		$this->localDomain = \rtrim((string) \preg_replace('/(?:https?:)?\/\//i', '', $localDomain), '/');
 
-        return $this;
-    }
-
-    /**
-     * @param string $localDomain
-     *
-     * @return $this
-     */
-    public function setLocalDomain(string $localDomain = ''): self
-    {
-        $this->localDomain = \rtrim((string) \preg_replace('/(?:https?:)?\/\//i', '', $localDomain), '/');
+		$this->doMakeSameDomainLinksRelative = ($this->localDomain !== '');
 
         return $this;
     }
@@ -1124,14 +1114,6 @@ class HtmlMin implements HtmlMinInterface
     public function isDoMakeSameDomainLinksRelative(): bool
     {
         return $this->doMakeSameDomainLinksRelative;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isLocalDomainSet(): bool
-    {
-        return $this->localDomain !== '';
     }
 
     /**

--- a/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
+++ b/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
@@ -68,7 +68,7 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
                     $attrValue,
                     $attrName,
                     'http',
-                    $attributes,
+					$attributes,
 					$tag_name,
                     $htmlMin
                 );
@@ -79,16 +79,13 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
                     $attrValue,
                     $attrName,
                     'https',
-                    $attributes,
+					$attributes,
 					$tag_name,
                     $htmlMin
                 );
             }
 
             if ($htmlMin->isDoMakeSameDomainLinksRelative()) {
-                if (!$htmlMin->isLocalDomainSet()) {
-                    $htmlMin->setLocalDomain();
-                }
 
                 $localDomain = $htmlMin->getLocalDomain();
                 /** @noinspection InArrayCanBeUsedInspection */
@@ -250,7 +247,7 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
         string $attrValue,
         string $attrName,
         string $scheme,
-        array $attributes,
+		array $attributes,
 		string $tag_name,
         HtmlMinInterface $htmlMin
     ): string {
@@ -265,10 +262,10 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
                     $attrName === 'href'
                     &&
 					(
-                    !$htmlMin->isKeepPrefixOnExternalAttributes()
+						!$htmlMin->isKeepPrefixOnExternalAttributes()
 						||
 						$tag_name === 'link'
-                )
+					)
 				)
                 ||
                 $attrName === 'src'

--- a/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
+++ b/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
@@ -50,7 +50,7 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
      */
     public function domElementAfterMinification(SimpleHtmlDomInterface $element, HtmlMinInterface $htmlMin)
     {
-		$tag_name = $node->nodeName;
+		$tag_name = $element->getNode()->nodeName;
         $attributes = $element->getAllAttributes();
         if ($attributes === null) {
             return;

--- a/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
+++ b/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
@@ -50,6 +50,7 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
      */
     public function domElementAfterMinification(SimpleHtmlDomInterface $element, HtmlMinInterface $htmlMin)
     {
+		$tag_name = $node->nodeName;
         $attributes = $element->getAllAttributes();
         if ($attributes === null) {
             return;
@@ -68,6 +69,7 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
                     $attrName,
                     'http',
                     $attributes,
+					$tag_name,
                     $htmlMin
                 );
             }
@@ -78,6 +80,7 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
                     $attrName,
                     'https',
                     $attributes,
+					$tag_name,
                     $htmlMin
                 );
             }
@@ -248,6 +251,7 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
         string $attrName,
         string $scheme,
         array $attributes,
+		string $tag_name,
         HtmlMinInterface $htmlMin
     ): string {
         /** @noinspection InArrayCanBeUsedInspection */
@@ -260,8 +264,12 @@ final class HtmlMinDomObserverOptimizeAttributes implements HtmlMinDomObserverIn
                 (
                     $attrName === 'href'
                     &&
+					(
                     !$htmlMin->isKeepPrefixOnExternalAttributes()
+						||
+						$tag_name === 'link'
                 )
+				)
                 ||
                 $attrName === 'src'
                 ||

--- a/src/voku/helper/HtmlMinInterface.php
+++ b/src/voku/helper/HtmlMinInterface.php
@@ -118,21 +118,9 @@ interface HtmlMinInterface
     public function isDoMakeSameDomainLinksRelative(): bool;
 
     /**
-     * @return bool
-     */
-    public function isLocalDomainSet(): bool;
-
-    /**
      * @return string
      */
     public function getLocalDomain(): string;
-
-    /**
-     * @param string $localDomain
-     *
-     * @return self
-     */
-    public function setLocalDomain(string $localDomain = '');
 
     /**
      * @return array

--- a/tests/HtmlMinTest.php
+++ b/tests/HtmlMinTest.php
@@ -1248,19 +1248,7 @@ HTML;
         $expected = '<a href=/>Just an example</a>';
 
         $htmlMin = new HtmlMin();
-        $htmlMin->doMakeSameDomainLinksRelative();
-        $htmlMin->setLocalDomain('www.example.com');
-        static::assertSame($expected, $htmlMin->minify($html));
-    }
-
-    public function testSetLocalDomain()
-    {
-        $html = '<a href="www.example.com">Just an example</a>';
-        $expected = '<a href=/>Just an example</a>';
-
-        $htmlMin = new HtmlMin();
-        $htmlMin->doMakeSameDomainLinksRelative();
-        $htmlMin->setLocalDomain('https://www.example.com/');
+        $htmlMin->doMakeSameDomainLinksRelative('www.example.com');
         static::assertSame($expected, $htmlMin->minify($html));
 
         // --
@@ -1269,8 +1257,7 @@ HTML;
         $expected = '<a href=/>Just an example</a>';
 
         $htmlMin = new HtmlMin();
-        $htmlMin->doMakeSameDomainLinksRelative();
-        $htmlMin->setLocalDomain('https://www.example.com/');
+        $htmlMin->doMakeSameDomainLinksRelative('https://www.example.com/');
         static::assertSame($expected, $htmlMin->minify($html));
 
         // --
@@ -1279,8 +1266,7 @@ HTML;
         $expected = '<a href=/foo/bar>Just an example</a>';
 
         $htmlMin = new HtmlMin();
-        $htmlMin->doMakeSameDomainLinksRelative();
-        $htmlMin->setLocalDomain('httpS://www.example.com/');
+        $htmlMin->doMakeSameDomainLinksRelative('httpS://www.example.com/');
         static::assertSame($expected, $htmlMin->minify($html));
 
         // --
@@ -1289,8 +1275,7 @@ HTML;
         $expected = '<a href=/foo/bar>Just an example</a>';
 
         $htmlMin = new HtmlMin();
-        $htmlMin->doMakeSameDomainLinksRelative();
-        $htmlMin->setLocalDomain('www.Example.com');
+        $htmlMin->doMakeSameDomainLinksRelative('www.Example.com');
         static::assertSame($expected, $htmlMin->minify($html));
 
         // --
@@ -1299,8 +1284,7 @@ HTML;
         $expected = '<a href=/foo/bar>Just an example</a>';
 
         $htmlMin = new HtmlMin();
-        $htmlMin->doMakeSameDomainLinksRelative();
-        $htmlMin->setLocalDomain('موقع.وزارة-الاتصالات.مصر');
+        $htmlMin->doMakeSameDomainLinksRelative('موقع.وزارة-الاتصالات.مصر');
         static::assertSame($expected, $htmlMin->minify($html));
 
         // --
@@ -1308,8 +1292,7 @@ HTML;
         $html = '<a href=HTTPS://موقع.وزارة-الاتصالات.مصر/foo/bar target=_blank>Just an example</a>';
 
         $htmlMin = new HtmlMin();
-        $htmlMin->doMakeSameDomainLinksRelative();
-        $htmlMin->setLocalDomain('موقع.وزارة-الاتصالات.مصر');
+        $htmlMin->doMakeSameDomainLinksRelative('موقع.وزارة-الاتصالات.مصر');
         static::assertSame($html, $htmlMin->minify($html));
 
         // --
@@ -1317,8 +1300,7 @@ HTML;
         $html = '<a href=HTTPS://موقع.وزارة-الاتصالات.مصر/foo/bar rel=external>Just an example</a>';
 
         $htmlMin = new HtmlMin();
-        $htmlMin->doMakeSameDomainLinksRelative();
-        $htmlMin->setLocalDomain('موقع.وزارة-الاتصالات.مصر');
+        $htmlMin->doMakeSameDomainLinksRelative('موقع.وزارة-الاتصالات.مصر');
         static::assertSame($html, $htmlMin->minify($html));
     }
 
@@ -1330,6 +1312,16 @@ HTML;
         $htmlMin = new HtmlMin();
         $htmlMin->doRemoveHttpPrefixFromAttributes();
         $htmlMin->keepPrefixOnExternalAttributes();
-        static::assertSame($expected, $htmlMin->minify($html));
+		static::assertSame($expected, $htmlMin->minify($html));
+		
+		// --
+
+		$html = '<html><head><link href="http://www.example.com/"></head><body><a href="http://www.example.com/">No remove</a><img src="http://www.example.com/" /></body></html>';
+		$expected = '<html><head><link href=//www.example.com/><body><a href=http://www.example.com/>No remove</a><img src=//www.example.com/>';
+		
+		$htmlMin = new HtmlMin();
+        $htmlMin->doRemoveHttpPrefixFromAttributes();
+        $htmlMin->keepPrefixOnExternalAttributes();
+		static::assertSame($expected, $htmlMin->minify($html));
     }
 }


### PR DESCRIPTION
Hi,
I made some changes and a fix to previous PR #44 in light of removal of `$_SERVER` usage. 

#### Proposed Changes
* `KeepPrefixOnExternal` does not affect `link` tags' `href` attribute. The `link` tag is not an external link. It's a resource that must adhere to `removePrefix`.
* `makeSameDomainLinksRelative()` accepts `$localDomain` string as parameter
* Removed method `setLocalDomain()` - functionality merged into `makeSameDomainLinksRelative()`
* Removed unnecessary call to `setLocalDomain()` with empty parameter It is up to user to provide a valid `localDomain` string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/htmlmin/45)
<!-- Reviewable:end -->
