### PR TITLE
Upgrade code to work in PHP8 or greater and/or Laravel 9 or greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ composer require voku/html-min
 ### Quick Start
 
 ```php
-use voku\helper\HtmlMin;
+use Voku\Helper\HtmlMin;
 
 $html = "
 <html>
@@ -50,7 +50,7 @@ echo $htmlMin->minify($html);
 ### Options
 
 ```php
-use voku\helper\HtmlMin;
+use Voku\Helper\HtmlMin;
 
 $htmlMin = new HtmlMin();
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0.0",
+    "php": "^8.0 || ^8.1 || ^8.2",
     "voku/simple_html_dom": "~4.8.5",
     "ext-dom": "*"
   },
@@ -27,7 +27,7 @@
   },
   "autoload": {
     "psr-4": {
-      "voku\\": "src/voku/"
+      "Voku\\": "src/voku/"
     }
   }
 }

--- a/src/voku/helper/HtmlMin.php
+++ b/src/voku/helper/HtmlMin.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * Class HtmlMin

--- a/src/voku/helper/HtmlMinDomObserverInterface.php
+++ b/src/voku/helper/HtmlMinDomObserverInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 interface HtmlMinDomObserverInterface
 {

--- a/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
+++ b/src/voku/helper/HtmlMinDomObserverOptimizeAttributes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * HtmlMinDomObserverOptimizeAttributes: Optimize html attributes. [protected html is still protected]

--- a/src/voku/helper/HtmlMinInterface.php
+++ b/src/voku/helper/HtmlMinInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 interface HtmlMinInterface
 {


### PR DESCRIPTION
**Fixes** https://github.com/voku/HtmlMin/issues/84

This repo doesn't work in PHP 8, 8.1 or 8.2 due to the namespaces not being Capitalized.

* Have updated the namespaces.
* Have updated `composer.json` and removed php 7 as security updates ended in 28 November 2022.
* Have updated readme with new namespaces

Need to update the connecting repos now.

### Linked to Pull Requests

https://github.com/voku/html-compress-twig/pull/5

https://github.com/voku/HtmlMin/pull/85

https://github.com/voku/simple_html_dom/pull/95

https://github.com/voku/simple-cache/pull/30

https://github.com/voku/portable-ascii/pull/87

### Tested on the following

Tested on PHP 8.2 and Laravel 9.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/htmlmin/85)
<!-- Reviewable:end -->
